### PR TITLE
pass 10 as second parameter to the calls of parseInt function

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -1,19 +1,19 @@
 /*
- 
- Holder - client side image placeholders
- (c) 2012 Ivan Malopinsky / http://imsky.co
- 
- Provided under the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
- Commercial use requires attribution.
- 
+
+Holder - client side image placeholders
+(c) 2012 Ivan Malopinsky / http://imsky.co
+
+Provided under the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+Commercial use requires attribution.
+
 */
 
 var Holder = Holder || {};
 (function (app, win) {
-    
+
 //http://javascript.nwbox.com/ContentLoaded by Diego Perini with modifications
 function contentLoaded(n,t){var l="complete",s="readystatechange",u=!1,h=u,c=!0,i=n.document,a=i.documentElement,e=i.addEventListener?"addEventListener":"attachEvent",v=i.addEventListener?"removeEventListener":"detachEvent",f=i.addEventListener?"":"on",r=function(e){(e.type!=s||i.readyState==l)&&((e.type=="load"?n:i)[v](f+e.type,r,u),!h&&(h=!0)&&t.call(n,null))},o=function(){try{a.doScroll("left")}catch(n){setTimeout(o,50);return}r("poll")};if(i.readyState==l)t.call(n,"lazy");else{if(i.createEventObject&&a.doScroll){try{c=!n.frameElement}catch(y){}c&&o()}i[e](f+"DOMContentLoaded",r,u),i[e](f+s,r,u),n[e](f+"load",r,u)}};
-	
+
 //https://gist.github.com/991057 by Jed Schmidt with modifications
 function selector(a){
 	a=a.match(/^(\W)?(.*)/);var b=document["getElement"+(a[1]?a[1]=="#"?"ById":"sByClassName":"sByTagName")](a[2]);
@@ -22,7 +22,7 @@ function selector(a){
 
 //shallow object property extend
 function extend(a,b){var c={};for(var d in a)c[d]=a[d];for(var e in b)c[e]=b[e];return c}
-	
+
 function draw(ctx, dimensions, template) {
 	var dimension_arr = [dimensions.height, dimensions.width].sort();
 	var maxFactor = Math.round(dimension_arr[1] / 16),
@@ -109,8 +109,8 @@ app.run = function (o) {
 				if (flags[j].match(dimensions_regex)) {
 					var exec = dimensions_regex.exec(flags[j])
 					dimensions = {
-						width: parseInt(exec[1]),
-						height: parseInt(exec[2])
+						width: parseInt(exec[1], 10),
+						height: parseInt(exec[2], 10)
 					}
 					render = true;
 				} else if (flags[j].match(hex_regex)) {


### PR DESCRIPTION
The regexp for parsing the dimensions of the image to generate allows for leading zeros. That's why it's important to pass 10 as second parameter to the calls of parseInt function. leading zeros lead to the numbers being interpreted in octal numeral system 020x100 would thus become 16 pixels by 100 instead of 20.
