### PR TITLE
Ignore data-src when src is real image.

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -212,7 +212,8 @@ app.run = function (o) {
 	}
 
 	for (var l = images.length, i = 0; i < l; i++) {
-		var src = images[i].getAttribute("data-src") || images[i].getAttribute("src");
+		var src = images[i].getAttribute("src") || null;
+		if (src == null) { src = images[i].getAttribute("data-src") || null; }
 		if (src != null && src.indexOf(options.domain)>=0) {
 			var holder = parse_flags(src.substr(src.lastIndexOf(options.domain) + options.domain.length + 1).split("/"), options);
 			if (holder) {


### PR DESCRIPTION
If both data-src and src are present, and src is set to something other
than holder.js (or other configured domain), leave the image untouched.

Someone using holder.js in a CMS template can then easily set just the src of the image instead of rewriting the entire image tag to override the holder.js fallback. Example:

``` php
<?php
// Set image source if available
$src = isset($realimg) ? " src='$realimg'" : ''; ?>
<img data-src="holder.js/500x300"<?php echo $src; ?> />
```
