### PR TITLE
AngularJS workaround

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -300,6 +300,22 @@ app.add_image = function (src, el) {
 	return app;
 };
 
+app.process_img = function (el, options) {
+	options = options || settings;
+	var src = el.getAttribute("src") || el.getAttribute("data-src");
+	if (src != null && src.indexOf(options.domain) >= 0) {
+		var holder = parse_flags(src.substr(src.lastIndexOf(options.domain) + options.domain.length + 1)
+			.split("/"), options);
+		if (holder) {
+			if (holder.fluid) {
+				fluid(el, holder, src);
+			} else {
+				render("image", el, holder, src);
+			}
+		}
+	}
+};
+
 app.run = function (o) {
 	var options = extend(settings, o),
 		images_nodes = selector(options.images),
@@ -329,18 +345,7 @@ app.run = function (o) {
 	}
 
 	for (var l = images.length, i = 0; i < l; i++) {
-		var src = images[i].getAttribute("src") || images[i].getAttribute("data-src");
-		if (src != null && src.indexOf(options.domain) >= 0) {
-			var holder = parse_flags(src.substr(src.lastIndexOf(options.domain) + options.domain.length + 1)
-				.split("/"), options);
-			if (holder) {
-				if (holder.fluid) {
-					fluid(images[i], holder, src);
-				} else {
-					render("image", images[i], holder, src);
-				}
-			}
-		}
+		app.process_img(images[i], options);
 	}
 	return app;
 };


### PR DESCRIPTION
This is a workaround to make holder work with AngularJS apps.

I'm not sure this is the best way to add this feature as I am both a new Angular and holder user.

The idea is to expose a method in the Holder global object that allows to process any given DOM img element, then use this method from a very short Angular directive which is called by the Angular framework during the link phase.

Usage

```
<img data-src="holder.js/360x270" bs-holder />
```

that's it. I named the Angular directive that way so that it can be included  into the project [angular-strap](https://github.com/mgcrea/angular-strap).

The workaround currently only supports the src/data-src method. No regression test have been achieved to test if the regular way of using holder still work (as I have no project using it outside of my first Angular app). But should be ok as the patch is very simple (just moved code into a new method).

Here is the Angular directive source-code (which is not included in my pull request)

```
directive('bsHolder', function() {
  return {
    link: function (scope, element, attrs) {
      Holder.process_img(element.get(0));
    }
  };
})
```
