### PR TITLE
Check and account for high-res canvas.

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -90,6 +90,9 @@ function render(mode, el, holder, src) {
 	if (window.devicePixelRatio && window.devicePixelRatio > 1) {
 		ratio = window.devicePixelRatio;
 	}
+	if (ctx.webkitBackingStorePixelRatio && ctx.webkitBackingStorePixelRatio > 1) {
+		ratio = 1;
+	}
 
 	if (mode == "image") {
 		el.setAttribute("data-src", src);


### PR DESCRIPTION
Retina MacBook Pros running Safari 6 automatically increase the pixel
ratio of canvas elements, so also multiplying by the devicePixelRatio
is excessive.

http://www.html5rocks.com/en/tutorials/canvas/hidpi/
