### PR TITLE
Fixed AMD loader line

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -413,7 +413,7 @@ contentLoaded(win, function () {
 });
 
 if (typeof define === "function" && define.amd) {
-	define("Holder", [], function () {
+	define([], function () {
 		return app;
 	});
 }


### PR DESCRIPTION
Require.js blows up if the module name is specified
