### PR TITLE
Replace comma with semicolon

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -30,7 +30,7 @@ if (!canvas.getContext) {
 }
 
 if(!fallback){
-    dpr = window.devicePixelRatio || 1,
+    dpr = window.devicePixelRatio || 1;
     bsr = ctx.webkitBackingStorePixelRatio || ctx.mozBackingStorePixelRatio || ctx.msBackingStorePixelRatio || ctx.oBackingStorePixelRatio || ctx.backingStorePixelRatio || 1;
 }
 


### PR DESCRIPTION
I'm not a javascript expert, but for me it seems the comma after assigning a variable is somehow wrong. It works but still does not look correct.
