### PR TITLE
Use "/*!" to ensure attribution comment is preserved

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -1,4 +1,4 @@
-/*
+/*!
 
 Holder - 2.3 - client side image placeholders
 (c) 2012-2014 Ivan Malopinsky / http://imsky.co


### PR DESCRIPTION
There is a convention among JS (and CSS) minifiers that comments which use the `/*! ... */` format will be preserved.
This is primarily intended to be used for licensing and attribution information, like this file header comment.
