### PR TITLE
Removed empty dependencies from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,5 @@
 {
   "name": "holderjs",
   "version": "2.3.1",
-  "main": "holder.js",
-  "dependencies": {
-  }
+  "main": "holder.js"
 }


### PR DESCRIPTION
There is no need to have an empty `dependencies` entry there
