### PR TITLE
[bug] fixed the bug when src not null.

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -584,7 +584,7 @@ app.run = function (o) {
 		} catch (e) {}
 		if (attr_datasrc == null && !! attr_src && attr_src.indexOf(options.domain) >= 0) {
 			src = attr_src;
-		} else if ( !! attr_datasrc && attr_datasrc.indexOf(options.domain) >= 0) {
+		} else if ( !! attr_src && attr_datasrc.indexOf(options.domain) >= 0) {
 			src = attr_datasrc;
 		}
 		if (src) {


### PR DESCRIPTION
Steps to Reproduce:
1. html:
`<img src="http://xxxx.jpg" data-src="holder.js/100x200" >`
2.trigger window `resize` event.

the img.src will be holder datasrc.

Thanks!
