### PR TITLE
[minor]Don't update, when image attribute 'src' has changed

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -213,7 +213,7 @@ function draw_canvas(args) {
 		height = dimensions.height * ratio;
 	var font = template.font ? template.font : "Arial,Helvetica,sans-serif";
 	var font_weight = template.fontweight ? template.fontweight : "bold";
-			font_weight = font_weight == "normal" ? "" : font_weight;
+	font_weight = font_weight == "normal" ? "" : font_weight;
 	canvas.width = width;
 	canvas.height = height;
 	ctx.textAlign = "center";
@@ -222,6 +222,7 @@ function draw_canvas(args) {
 	ctx.fillRect(0, 0, width, height);
 	ctx.fillStyle = template.foreground;
 	ctx.font = font_weight + " " + text_height + "px " + font;
+
 	var text = template.text ? template.text : (Math.floor(dimensions.width) + "x" + Math.floor(dimensions.height));
 	if (literal) {
 		var dimensions = holder.dimensions;
@@ -632,7 +633,7 @@ if (typeof define === "function" && define.amd) {
 }
 
 //github.com/davidchambers/Base64.js
-(function(){function t(t){this.message=t}var e="undefined"!=typeof exports?exports:this,r="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";t.prototype=Error(),t.prototype.name="InvalidCharacterError",e.btoa||(e.btoa=function(e){for(var o,n,a=0,i=r,c="";e.charAt(0|a)||(i="=",a%1);c+=i.charAt(63&o>>8-8*(a%1))){if(n=e.charCodeAt(a+=.75),n>255)throw new t("'btoa' failed");o=o<<8|n}return c}),e.atob||(e.atob=function(e){if(e=e.replace(/=+$/,""),1==e.length%4)throw new t("'atob' failed");for(var o,n,a=0,i=0,c="";n=e.charAt(i++);~n&&(o=a%4?64*o+n:n,a++%4)?c+=String.fromCharCode(255&o>>(6&-2*a)):0)n=r.indexOf(n);return c})})();
+(function(){function t(t){this.message=t}var e="undefined"!=typeof exports?exports:this,r="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";t.prototype=Error(),t.prototype.name="InvalidCharacterError",e.btoa||(e.btoa=function(e){for(var o,n,a=0,i=r,c="";e.charAt(0|a)||(i="=",a%1);c+=i.charAt(63&o>>8-8*(a%1))){if(n=e.charCodeAt(a+=0.75),n>255)throw new t("'btoa' failed");o=o<<8|n}return c}),e.atob||(e.atob=function(e){if(e=e.replace(/=+$/,""),1==e.length%4)throw new t("'atob' failed");for(var o,n,a=0,i=0,c="";n=e.charAt(i++);~n&&(o=a%4?64*o+n:n,a++%4)?c+=String.fromCharCode(255&o>>(6&-2*a)):0)n=r.indexOf(n);return c})})();
 
 //getElementsByClassName polyfill
 document.getElementsByClassName||(document.getElementsByClassName=function(e){var t=document,n,r,i,s=[];if(t.querySelectorAll)return t.querySelectorAll("."+e);if(t.evaluate){r=".//*[contains(concat(' ', @class, ' '), ' "+e+" ')]",n=t.evaluate(r,t,null,0,null);while(i=n.iterateNext())s.push(i)}else{n=t.getElementsByTagName("*"),r=new RegExp("(^|\\s)"+e+"(\\s|$)");for(i=0;i<n.length;i++)r.test(n[i].className)&&s.push(n[i])}return s});


### PR DESCRIPTION
Hello, imsky, I have a suggestion: 

When I modified the holder image src attribute, and then the window resize event is triggered, the picture should not be reduced to the svg.

Setp to reproduce:
1. html:

``` html
<img src="" id="preview-img" data-src="holder.js/100x200" >
```

2.When I finished uploading a picture, and then I modified the holder image attribute src:

``` javascript
...
$('#preview-img').attr('src', 'http://xxxx.jpg');
...
```

3.trigger window resize event.

the image attribue `src` will become `data:image/svg+xml;base64,...`

Also, I complement the end of the line ';'.

Thanks!
