### PR TITLE
Added remove_from_resize method

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -518,6 +518,23 @@ app.add_image = function (src, el) {
 	return app;
 };
 
+app.remove_from_resize = function(el) {
+	var node = selector(el);
+	if (node.length) {
+		for (var i = 0, l = node.length; i < l; i++) {
+			// Need resizable_images.length because of the possibility of shortening
+			// the array when spliced on a match.  Also, avoid 'break' in the loop
+			// on match in case the element has (somehow) been added more than once.
+			for (var j = 0; j < resizable_images.length; j++) {
+				if (node[i] === resizable_images[j]) {
+					resizable_images.splice(j, 1);
+				}
+			}
+		}
+	}
+	return app;
+};
+
 app.run = function (o) {
 
 	instance_config = extend({}, system_config)


### PR DESCRIPTION
Added the ability to remove an image from the resizable_images array.  Allows for temporarily disabling the re-rendering of the image on window resize.  To re-enable, simply call `run()` and the image will be placed back in the array.

I thought about performing a check on the `src` attribute inside `resizable_update()`, but that only handles the case when the `src` has been changed.  Sometimes I just want to stop it from rendering regardless of any changes made to the element.