### PR TITLE
Percent decoding on validate fluid URI

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -97,7 +97,7 @@ app.flags = {
 	fluid: {
 		regex: /^([0-9%]+)x([0-9%]+)$/,
 		output: function (val) {
-			var exec = this.regex.exec(val);
+			var exec = this.regex.exec(val.replace(/%25/g, '%'));
 			return {
 				width: exec[1],
 				height: exec[2]


### PR DESCRIPTION
This PR would allowing validate URI like `100%25x60` to be percent decoding to `100%x60` as desired setting.

> Because the percent ("%") character serves as the indicator for percent-encoded octets, it must be percent-encoded as "%25" for that octet to be used as data within a URI. -- [rfc3986#section-2.4](http://tools.ietf.org/html/rfc3986#section-2.4)
