### PR TITLE
Fix missing license for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,5 @@
 {
   "name": "holderjs",
-  "main": "holder.js"
+  "main": "holder.js",
+  "license": "MIT"
 }


### PR DESCRIPTION
I'm not sure I'm supposed to propose such a patch, even if minor change, 
from a licensing point of view, this is not minor at all.

This is required to be able to publish this (great) project on webjar with bower. 