### PR TITLE
Fixed IE8 compatibility issue.

### DIFF
--- a/holder.js
+++ b/holder.js
@@ -2748,7 +2748,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				returnObject[reference[1]] = element
 
 			if (classNames)
-				element.attr.class = classNames.join(' ').replace(/\./g, '')
+				element.attr['class'] = classNames.join(' ').replace(/\./g, '')
 
 			if (sugarString.match(/&$/g))
 				doesEscape = false


### PR DESCRIPTION
I'll be *that guy*.

IE<9 doesn't allow accessing attributes named after reserved words with dot
notation.

Fixed, works fine once shims for some other ~weird IE behavior~ are loaded.