### PR TITLE
Shaven 0.8.1 not capable with node^6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "test": "node test/index"
   },
   "dependencies": {
-    "shaven": "^0.8.1"
+    "shaven": "^1.1.0"
   }
 }


### PR DESCRIPTION
Unsupported engine for shaven@0.8.1: wanted: {"node":"~0.12.2"} (current: {"node":"6.10.3","npm":"3.10.10"})