### PR TITLE
rgba without leading zero

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -146,8 +146,8 @@ exports.parseColor = function(val) {
     match = val.match(rgbare);
 
     if (match !== null) {
-        const fixAlpha = a => `0.${a.split('.')[1]}`
-        const fixedMatch = match.slice(1).map((e, i) => (i === 3) ? fixAlpha(e) : e)
+        const normalizeAlpha = a => `0.${a.split('.')[1]}`
+        const fixedMatch = match.slice(1).map((e, i) => (i === 3) ? normalizeAlpha(e) : e)
         retval = 'rgba(' + fixedMatch.join(',') + ')';
         return retval;
     }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -122,7 +122,7 @@ exports.truthy = function(val) {
 exports.parseColor = function(val) {
     var hexre = /(^(?:#?)[0-9a-f]{6}$)|(^(?:#?)[0-9a-f]{3}$)/i;
     var rgbre = /^rgb\((\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/;
-    var rgbare = /^rgba\((\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0\.\d{1,}|1)\)$/;
+    var rgbare = /^rgba\((\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0*\.\d{1,}|1)\)$/;
 
     var match = val.match(hexre);
     var retval;
@@ -146,7 +146,9 @@ exports.parseColor = function(val) {
     match = val.match(rgbare);
 
     if (match !== null) {
-        retval = 'rgba(' + match.slice(1).join(',') + ')';
+        const fixAlpha = a => `0.${a.split('.')[1]}`
+        const fixedMatch = match.slice(1).map((e, i) => (i === 3) ? fixAlpha(e) : e)
+        retval = 'rgba(' + fixedMatch.join(',') + ')';
         return retval;
     }
 


### PR DESCRIPTION
This PR fixes #205.

- The `rgbare` RegEx accepts 0 or 1 `0` character in the alpha field.
- The alpha field is then normalized so it always outputs `0.##`, so as far as the rest of the library is concerned, the output of `parseColor` remains unchanged (for example `rgba(123,123,123,0.4)`).