### PR TITLE
Document the holder_dimensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ If you would like to disable line wrapping, set the `nowrap` option to `true`:
 <img data-src="holder.js/300x200?text=Add \n line breaks \n anywhere.&amp;nowrap=true">
 ```
 
+When using the `text` option, the image dimesions are not shown. To reinsert the dimension into the text, simple use the special `holder_dimensions` placeholder. 
+
+```html
+<img data-src="holder.js/90px80p?theme=sky&text=Placeholder dimensions: holder_dimensions">
+```
+
 Placeholders using a custom font are rendered using canvas by default, due to SVG's constraints on cross-domain resource linking. If you're using only locally available fonts, you can disable this behavior by setting `noFontFallback` to `true` in `Holder.run` options. However, if you need to render a SVG placeholder using an externally loaded font, you have to use the `object` tag instead of the `img` tag and add a `holderjs` class to the appropriate `link` tags. Here's an example:
 
 ```html


### PR DESCRIPTION
The holder_dimensions option is undocumented. This just adds a bit of text about using it.