### PR TITLE
Allow fixed font size with automatically sized images

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -359,6 +359,10 @@ function parseURL(url, instanceOptions) {
         if (options.size && parseFloat(options.size)) {
             holder.size = parseFloat(options.size);
         }
+        
+        if (options.fixedSize != null) {
+            holder.fixedSize = utils.truthy(options.fixedSize);
+        }
 
         if (options.font) {
             holder.font = options.font;
@@ -649,6 +653,7 @@ function render(renderSettings) {
 //todo: merge app defaults and setup properties into the scene argument
 function buildSceneGraph(scene) {
     var fontSize = App.defaults.size;
+    var fixedSize = scene.flags.fixedSize != null ? scene.flags.fixedSize : scene.theme.fixedSize;
     if (parseFloat(scene.theme.size)) {
         fontSize = scene.theme.size;
     } else if (parseFloat(scene.flags.size)) {
@@ -657,7 +662,7 @@ function buildSceneGraph(scene) {
 
     scene.font = {
         family: scene.theme.font ? scene.theme.font : 'Arial, Helvetica, Open Sans, sans-serif',
-        size: textSize(scene.width, scene.height, fontSize, App.defaults.scale),
+        size: fixedSize ? fontSize : textSize(scene.width, scene.height, fontSize, App.defaults.scale),
         units: scene.theme.units ? scene.theme.units : App.defaults.units,
         weight: scene.theme.fontweight ? scene.theme.fontweight : 'bold'
     };

--- a/test/index.html
+++ b/test/index.html
@@ -316,6 +316,12 @@
 	</div>
 </div>
 <div class="fullpage thumb">
+	<img data-src="holder.js/90px80?size=10&fixedSize=yes">
+	<div class="caption">
+		 Full-page fluid placewholder with fixed font size
+	</div>
+</div>
+<div class="fullpage thumb">
 	<img data-src="holder.js/90px80" id="toggleResize">
 	<div class="caption">
 		 Full-page fluid placeholder that toggles resizable updates when clicked


### PR DESCRIPTION
This should fix #217 without changing the behavior of existing code, i.e. the font size of dynamically sized placeholders will continue to be dynamically sized.

This default can be changed via the `fixedSize` option for individual placeholders or as part of a theme. Example:
```html
<img data-src="holder.js/100px77?size=10">
<!-- => Same behavior as before: Size is ignored -->

<img data-src="holder.js/100px77?size=10&fixedSize=yes">
<!-- => Size is fixed to 10 -->
```

If potentially breaking existing code is not an issue, one could of course set `fixedSize` implicitly whenever a `size` is provided in the flags of an individual image. Feel free to merge 56f141a3ecbcf096edad80614d1275e39b049f73, if you prefer this approach.